### PR TITLE
Add benchmark Apple M1 Max for Tuniu 1

### DIFF
--- a/data-parsed/by-dataset.txt
+++ b/data-parsed/by-dataset.txt
@@ -300,6 +300,7 @@ This dataset is from the [ODMData](https://github.com/OpenDroneMap/ODMdata) coll
    Tuniu 1 |  3h 29m | 2020-04-01 |  16 GB |     Intel i5 |     4 |  0.9.8 |   3D Model |    2048 |                  | 
    Tuniu 1 |  0h 37m | 2022-01-27 |  56 GB | Xeon E5-1620 |     8 |  2.7.2 |    Default |    2048 |                  | 
    Tuniu 1 |  0h 37m | 2022-04-30 |  56 GB | Xeon E5-1620 |     8 |  2.8.4 |    Default |    2048 |                  | 
+   Tuniu 1 |  0h 18m | 2022-05-16 |  32 GB | Apple M1 Max |     8 |  2.8.4 |    Default |    2048 |                  | 
 
 
 Tuniu 2

--- a/data-parsed/by-version.txt
+++ b/data-parsed/by-version.txt
@@ -21,6 +21,7 @@ Brighton B |   0h 5m | 2022-04-30 |  56 GB | Xeon E5-1620 |     8 |  2.8.4 |    
        Zoo |  1h 28m | 2022-04-30 |  56 GB | Xeon E5-1620 |     8 |  2.8.4 |    Default |    2048 |                  | 
        Zoo |  1h 22m | 2022-04-30 |  56 GB | Xeon E5-1620 |     8 |  2.8.4 |    Default |    2048 |                  | 
     Shitan |  1h 41m | 2022-04-30 |  56 GB | Xeon E5-1620 |     8 |  2.8.4 |    Default |    2048 |                  | 
+   Tuniu 1 |  0h 18m | 2022-05-16 |  32 GB | Apple M1 Max |     8 |  2.8.4 |    Default |    2048 |                  | 
 
 
 OpenDroneMap Version 2.7.2

--- a/data/benchmarks.csv
+++ b/data/benchmarks.csv
@@ -156,3 +156,4 @@ ID,DATASET,PROCESSING_TIME,PROCESSING_SUCCESS,ERROR_TYPE,RAM_SIZE,RAM_CLOCK_SPEE
 156,Zoo,1h 28m,Y,-,56 GB,1333 MT/s,Xeon E5-1620,3.6 Ghz,8,HDD,Ubuntu 20.04,Docker,2.8.4,N,Default,2048,,2022-04-30,[Corey Snipes](https://github.com/coreysnipes/),-
 157,Zoo,1h 22m,Y,-,56 GB,1333 MT/s,Xeon E5-1620,3.6 Ghz,8,HDD,Ubuntu 20.04,Docker,2.8.4,N,Default,2048,,2022-04-30,[Corey Snipes](https://github.com/coreysnipes/),-
 158,Shitan,1h 41m,Y,-,56 GB,1333 MT/s,Xeon E5-1620,3.6 Ghz,8,HDD,Ubuntu 20.04,Docker,2.8.4,N,Default,2048,,2022-04-30,[Corey Snipes](https://github.com/coreysnipes/),-
+159,Tuniu 1,0h 18m,Y,-,32 GB,6400 MT/s,Apple M1 Max,3.2 Ghz,8,SSD,Mac OS 12.3.1,Docker,2.8.4,N,Default,2048,,2022-05-16,[Martin Riedel](https://github.com/rado0x54/),8 cores due to Docker restriction


### PR DESCRIPTION
The processing time is taken from WebODM UI. Hope that is the correct benchmark value.

![Screen Shot 2022-05-16 at 3 59 33 PM](https://user-images.githubusercontent.com/1713643/168672515-e4dda8fc-03f8-4418-a616-d1833e4c3c10.png)
e